### PR TITLE
Remove obsolete Lando bootstrap handling

### DIFF
--- a/web/sites/site.settings.php
+++ b/web/sites/site.settings.php
@@ -109,10 +109,6 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
   $settings['simple_environment_indicator'] = sprintf('%s %s', $env_colour, $env_name);
 }
 
-if (getenv('LANDO') && file_exists($app_root . '/sites/settings.lando.php')) {
-  include $app_root . '/sites/settings.lando.php';
-}
-
 if (getenv('IS_DDEV_PROJECT') && file_exists($app_root . '/sites/settings.ddev.php')) {
   include $app_root . '/sites/settings.ddev.php';
 }

--- a/web/sites/sites.php
+++ b/web/sites/sites.php
@@ -58,7 +58,7 @@
  */
 
 // Different sites setup depending on whether we are running on
-// Platform.sh or local Lando
+// Platform.sh or local DDEV.
 use Symfony\Component\Yaml\Yaml;
 
 $sites = [];
@@ -108,31 +108,7 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
   }
 }
 
-// Running in Lando locally, include appropriate sites file.
-if (getenv('LANDO')) {
-  $project = Yaml::parseFile('/app/project/project.yml');
-
-  foreach ($project['sites'] as $site_id => $site) {
-    if ($site_id == 'mentalhealthchampionni') {
-      // Special case for URL that contains a '-'
-      $sites['mentalhealthchampion-ni.org.uk.lndo.site'] = $site_id;
-    }
-    elseif ($site_id == 'infolibrarynics') {
-      $sites['info.library.nics.gov.uk.lndo.site'] = $site_id;
-    }
-    elseif ($site_id == 'pressclippingsnics') {
-      $sites['pressclippings.nics.gov.uk.lndo.site'] = $site_id;
-    }
-    elseif ($site_id == 'independentpaneltruthrecoveryni') {
-      $sites['independentpanel.truthrecoveryni.co.uk.lndo.site'] = $site_id;
-    }
-    else {
-      $sites[$site['url'] . '.lndo.site'] = $site_id;
-    }
-  }
-}
-
-// Running in DDev locally, include appropriate sites file.
+// Running in DDEV locally, include the appropriate sites file.
 if (getenv('IS_DDEV_PROJECT')) {
   $project = Yaml::parseFile('/var/www/html/project/project.yml');
 


### PR DESCRIPTION
Propagates the Unity Lando cleanup into the upstream Maestro template so the repositories remain aligned.

Changes:
- Remove the settings.lando.php include.
- Remove local lndo.site routing.
- Update the local environment comments to refer to DDEV.

Validation:
- PHP syntax checks pass for both files.
- git diff --check passes.
- Both files match nicsdru_unity PR #2237 byte-for-byte.

This also allows the Unity check_illegal_updates job to proceed after the maestro-hosting 1.2.3 lockfile fix.